### PR TITLE
remove cache mount

### DIFF
--- a/rootdir/fstab.tone
+++ b/rootdir/fstab.tone
@@ -1,7 +1,6 @@
 /dev/block/bootdevice/by-name/system       /system      ext4    rw,barrier=1                                                  wait
 /dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait
 /dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
-/dev/block/bootdevice/by-name/userdata     /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults


### PR DESCRIPTION
Halium boot has a code path when cache is not there, this allows tone
and loire devices to download OTA files to userdata/cache/recovery.
When cache is mounted by android fstab/init this will not work and we
end up with two recovery directories and OTA breaking.